### PR TITLE
Bugfix/#2

### DIFF
--- a/api/packages/repository.go
+++ b/api/packages/repository.go
@@ -113,7 +113,7 @@ func (r *repository) DeletePackage(oid *primitive.ObjectID) (int, *Package) {
 
 	err := result.Decode(&packageDeleted)
 
-	if err == nil {
+	if err != nil {
 		log.Println("No pudo borrarse el paquete")
 		return http.StatusInternalServerError, nil
 	}


### PR DESCRIPTION
Se devolvia codigo 500 cuando no habia error al borrar un envase